### PR TITLE
put iredis.log in $HOME/iredis.log

### DIFF
--- a/iredis/__init__.py
+++ b/iredis/__init__.py
@@ -6,7 +6,7 @@ __version__ = "0.7.0"
 
 
 logging.basicConfig(
-    filename="iredis.log",
+    filename=os.path.join(os.getenv("HOME"), ".iredis.log"),
     filemode="a",
     format="%(levelname)5s %(message)s",
     level="DEBUG",


### PR DESCRIPTION
`iredis.log` should located at some specific location? Maybe it is associated #191 

Is it right? 