### PR TITLE
bugfix: when connect error on startup, should

### DIFF
--- a/iredis/client.py
+++ b/iredis/client.py
@@ -66,12 +66,15 @@ class Client:
         # all command upper case
         self.answer_callbacks = command2callback
         self.callbacks = self.reder_funcname_mapping()
-        self.connection.connect()
+        try:
+            self.connection.connect()
+        except Exception as e:
+            print(str(e), file=sys.stderr)
         if not config.no_info:
             try:
                 self.get_server_info()
             except Exception as e:
-                logger.warn(f"[After Connection] {str(e)}")
+                logger.warning(f"[After Connection] {str(e)}")
                 config.no_version_reason = str(e)
         else:
             config.no_version_reason = "--no-info flag activated"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -212,4 +212,4 @@ def test_running_with_multiple_pipeline(clean_redis, iredis_client, capfd):
 def test_can_not_connect_on_startup(capfd):
     Client("localhost", "16111", 15)
     out, err = capfd.readouterr()
-    assert err == "Error 61 connecting to localhost:16111. Connection refused.\n"
+    assert "connecting to localhost:16111." in err

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -207,3 +207,9 @@ def test_running_with_multiple_pipeline(clean_redis, iredis_client, capfd):
         )
     out, err = capfd.readouterr()
     assert out == "hello iredis\n"
+
+
+def test_can_not_connect_on_startup(capfd):
+    Client("localhost", "16111", 15)
+    out, err = capfd.readouterr()
+    assert err == "Error 61 connecting to localhost:16111. Connection refused.\n"


### PR DESCRIPTION
print a nicely error msg. not python stackstrace.

close #225 