### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ IRedis is an alternative for redis-cli. In most cases IRedis behaves exactly the
 - Command highlighting, fully based on redis grammar. Any valide command in iredis shell is a valide redis command.
 - Human friendly response display.
 - `peek` command to check the key's type then automaticly call `get`/`lrange`/`sscan`, etc, depends on types. You don't need to call `type` command then type another command to get value. `peek` will also display the key's length and memory usage.
-- <kbd>Ctrl</kbd> + <kbd>C</kbd> to clear cureent line, won't exit redis-cli. Use <kbd>Ctrl</kbd> + <kbd>D</kbd>
+- <kbd>Ctrl</kbd> + <kbd>C</kbd> to clear current line, won't exit redis-cli. Use <kbd>Ctrl</kbd> + <kbd>D</kbd>
 - Say "Goodbye!" to you when you exit!
 - <kbd>Ctrl</kbd> + <kbd>R</kbd> to open **reverse-i-search** to search through command history.
 - Auto suggestions. (Like [fish shell](http://fishshell.com/).)


### PR DESCRIPTION
`cureent` -> `current`.