### PR TITLE
bugfix: Peek command do not use MEMORY USAGE before redis 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 1.5
+
+- Bugfix: PEEK command do not use MEMORY USAGE before redis version 4.0.
+- Feature: Support disable shell pipeline feature in iredisrc. (Thanks
+  [wooden-robot])
+
 ### 1.4.3
 
 - Support `LOLWUT` command of Redis 6 version.

--- a/iredis/client.py
+++ b/iredis/client.py
@@ -500,7 +500,7 @@ class Client:
 
         encoding = nativestr(self.execute("object encoding", key))
 
-        # use `memory usage` to get memory, this command avaiable from redis4.0
+        # use `memory usage` to get memory, this command available from redis4.0
         mem = ""
         if config.version and StrictVersion(config.version) >= StrictVersion("4.0.0"):
             memory_usage_value = str(self.execute("memory usage", key))

--- a/iredis/client.py
+++ b/iredis/client.py
@@ -499,10 +499,16 @@ class Client:
             return
 
         encoding = nativestr(self.execute("object encoding", key))
-        memory_usage = str(self.execute("memory usage", key))
+
+        # use `memory usage` to get memory, this command avaiable from redis4.0
+        mem = ""
+        if config.version and StrictVersion(config.version) >= StrictVersion("4.0.0"):
+            memory_usage_value = str(self.execute("memory usage", key))
+            mem = f"  mem: {memory_usage_value} bytes"
+
         ttl = str(self.execute("ttl", key))
 
-        key_info = f"{key_type} ({encoding})  mem: {memory_usage} bytes, ttl: {ttl}"
+        key_info = f"{key_type} ({encoding}){mem}, ttl: {ttl}"
 
         # FIXME raw write_result parse FormattedText
         yield FormattedText([("class:dockey", "key: "), ("", key_info)])


### PR DESCRIPTION
close https://github.com/laixintao/iredis/issues/304