### PR TITLE
bugfix: --url option is not working

### DIFF
--- a/iredis/entry.py
+++ b/iredis/entry.py
@@ -439,7 +439,7 @@ def create_client(params):
     if dsn_from_url:
         # db from command lint options should be high priority
         db = db if db else dsn_from_url.db
-        client = Client(
+        return Client(
             host=dsn_from_url.host,
             port=dsn_from_url.port,
             db=db,
@@ -449,10 +449,8 @@ def create_client(params):
             username=dsn_from_url.username,
         )
     if params["socket"]:
-        client = Client(scheme="unix", path=params["socket"], db=db, password=password)
-    else:
-        client = Client(host=host, port=port, db=db, password=password)
-    return client
+        return Client(scheme="unix", path=params["socket"], db=db, password=password)
+    return Client(host=host, port=port, db=db, password=password)
 
 
 def main():

--- a/tests/cli_tests/test_cli_start.py
+++ b/tests/cli_tests/test_cli_start.py
@@ -1,5 +1,4 @@
 import pexpect
-import os
 import pytest
 from textwrap import dedent
 
@@ -45,12 +44,11 @@ def test_connection_using_url(clean_redis):
     c.close()
 
 
-def test_connection_using_url_from_env(clean_redis):
-    envs = os.environ
-    envs["IREDIS_URL"] = "redis://localhost:6379/7"
-    c = pexpect.spawn("iredis", timeout=2, env=envs)
+def test_connection_using_url_from_env(clean_redis, monkeypatch):
+    monkeypatch.setenv("IREDIS_URL", "redis://localhost:6379/7")
+    c = pexpect.spawn("iredis", timeout=2)
     c.logfile_read = open("cli_test.log", "ab")
-    c.expect(["iredis", "127.0.0.1:6379[7]>"])
+    c.expect(["iredis", "localhost:6379[7]>"])
     c.sendline("set current-db 7")
     c.expect("OK")
     c.close()

--- a/tests/cli_tests/test_dsn.py
+++ b/tests/cli_tests/test_dsn.py
@@ -1,5 +1,8 @@
+import os
+
 import pexpect
 from textwrap import dedent
+import pytest
 
 
 def test_using_dsn():
@@ -30,6 +33,9 @@ def test_using_dsn():
     assert cli.status == 1
 
 
+@pytest.mark.skipif(
+    not os.path.exists("/tmp/redis/redis.sock"), reason="unix socket is not found"
+)
 def test_using_dsn_unix():
     config_content = dedent(
         """


### PR DESCRIPTION

Thanks for the great product! I've been using it every day lately!


I've found a bug that doesn't work when you specify DSN using `--url` option.
In order to use SSL/TLS communication I need to use `rediss://` , so not working dsn is a serious problem for me.

Currently, it ignores --url option and connects to the default redis location as shown below

```bash
$ iredis --version
iredis, version 1.6.2

# redis is working at 127.0.0.1: 6379 and my.redis.local:16379
$ iredis -h 127.0.0.1 -p 6379 -n 0
iredis 1.6.2 (Python 3.7.5)
redis-server 5.0.8
Home: https://iredis.io
Issues: https://iredis.io/issues
127.0.0.1:6379[0]>
Goodbye!

$ iredis -h my.redis.local -p 16379 -n 0
iredis 1.6.2 (Python 3.7.5)
redis-server 5.0.7
Home: https://iredis.io
Issues: https://iredis.io/issues
my.redis.local:16379[0]>
Goodbye!

# --url option is ignored and connected to the default redis location
$ iredis --url 'redis://my.redis.local:16379/0'
iredis 1.6.2 (Python 3.7.5)
redis-server 5.0.8
Home: https://iredis.io
Issues: https://iredis.io/issues
127.0.0.1:6379>    # <------- CONNECTED TO 127.0.0.1:6379
Goodbye!
```

Fixed an unintentional overwriting of the client variable created by the --url option.

This fix caused the test to fail due to side effects from the environment variables `IREDIS_URL`.
The updating os.environ affects all tests in pytest.Use pytest's  `monkeypatch.setenv` so that the environment value is updated only by the scope of the function.
https://docs.pytest.org/en/latest/monkeypatch.html#monkeypatching-environment-variables

The test that specified the unix socket in dns was also failing. At least the socket path in GithubActions didn't seem to be `/tmp/redis/redis.sock` and it was failing the test. It's hard to pinpoint the path in various environments, so I changed this test to skip if unix socket is not found.

Thank you!
