### PR TITLE
add [] when argument is optional

### DIFF
--- a/iredis/utils.py
+++ b/iredis/utils.py
@@ -104,7 +104,10 @@ def parse_argument_to_formatted_text(
     result = []
     if isinstance(name, str):
         _type = type_convert.get(_type, _type)
-        result.append((f"class:{style_class}.{_type}", " " + name))
+        if is_option:
+            result.append((f"class:{style_class}.{_type}", f" [{name}]"))
+        else:
+            result.append((f"class:{style_class}.{_type}", f" {name}"))
     elif isinstance(name, list):
         for inner_name, inner_type in zip(name, _type):
             inner_type = type_convert.get(inner_type, inner_type)


### PR DESCRIPTION
When `name` is instance of `str` and argument is optional, value of `name` are not around by "[]". It's confused that using `XPENDING`，bottom-toolbar notices `(stream) XPENDING key group [start] [end] [count] consumer` and I think `consumer` is essential.But it's not so.

I added "[]" when argument is optional. How do you feel? 