### PR TITLE
docs: fix typo  valide->valid  internel->internal

### DIFF
--- a/iredis/bottom.py
+++ b/iredis/bottom.py
@@ -24,7 +24,7 @@ class BottomToolbar:
 
     def render(self):
         text = BUTTOM_TEXT
-        # add command help if valide
+        # add command help if valid
         if self.command_holder.command:
             try:
                 command_info = commands_summary[self.command_holder.command]

--- a/iredis/client.py
+++ b/iredis/client.py
@@ -486,7 +486,7 @@ class Client:
         redis_grammar = completer.get_completer(command).compiled_grammar
         m = redis_grammar.match(command)
         if not m:
-            # invalide command!
+            # invalid command!
             return
         variables = m.variables()
         # zset withscores
@@ -501,7 +501,7 @@ class Client:
             doc = read_text(commands_data, f"{command_docs_name}.md")
         except FileNotFoundError:
             raise NotRedisCommand(
-                f"{command_summary_name} is not a valide Redis command."
+                f"{command_summary_name} is not a valid Redis command."
             )
         rendered_detail = markdown.render(doc)
         summary_dict = commands_summary[command_summary_name]

--- a/iredis/client.py
+++ b/iredis/client.py
@@ -338,7 +338,7 @@ class Client:
         grammar = completer.get_completer(input_text=rawinput).compiled_grammar
         matched = grammar.match(rawinput)
         if not matched:
-            # invalide command!
+            # invalid command!
             return rawinput, None
         variables = matched.variables()
         shell_command = variables.get("shellcommand")

--- a/iredis/commands.py
+++ b/iredis/commands.py
@@ -135,7 +135,7 @@ def split_command_args(command):
             input_args = command[matcher.end() :]
             break
     else:
-        raise InvalidArguments(f"`{command}` is not a valide Redis Command")
+        raise InvalidArguments(f"`{command}` is not a valid Redis Command")
 
     args = list(strip_quote_args(input_args))
 

--- a/iredis/completers.py
+++ b/iredis/completers.py
@@ -191,7 +191,7 @@ class IRedisCompleter(Completer):
         grammar = completer.compiled_grammar
         m = grammar.match(command)
         if not m:
-            # invalide command!
+            # invalid command!
             return
         variables = m.variables()
 

--- a/iredis/renders.py
+++ b/iredis/renders.py
@@ -78,7 +78,7 @@ class OutputRender:
     @staticmethod
     def render_nested_pair(value):
         """
-        For redis internel responses.
+        For redis internal responses.
         Always decode with utf-8
         Render nested list.
         Items come as pairs.

--- a/iredis/utils.py
+++ b/iredis/utils.py
@@ -40,7 +40,7 @@ def literal_bytes(b):
     return b
 
 
-def _valide_token(words):
+def _valid_token(words):
     token = "".join(words).strip()
     if token:
         yield token


### PR DESCRIPTION
There are some small typo in `iredis`


> change `valide` to `valid`, change `invalide` to `invalid`, change `_valide_token` to `_valid_token`


> change `internel` to `internal`