### PR TITLE
Fix(shell-pipeline): Fix the type error when both use decode option a…

### DIFF
--- a/iredis/client.py
+++ b/iredis/client.py
@@ -407,12 +407,7 @@ class Client:
             # subcommand's stdout/stderr
             if shell_command and config.shell:
                 # pass the raw response of redis to shell command
-                if isinstance(redis_resp, list):
-                    # FIXME not handling nested list, use renders.render_raw
-                    # instead
-                    stdin = b"\n".join(redis_resp)
-                else:
-                    stdin = redis_resp
+                stdin = OutputRender.render_raw(redis_resp)
                 run(shell_command, input=stdin, shell=True)
                 return
 

--- a/iredis/renders.py
+++ b/iredis/renders.py
@@ -56,6 +56,8 @@ class OutputRender:
             return value
         if isinstance(value, int):
             return str(value).encode()
+        if isinstance(value, str):
+            return value.encode()
         if isinstance(value, list):
             return _render_raw_list(value)
 
@@ -344,6 +346,8 @@ def _render_raw_list(bytes_items):
             flatten_items.append(item)
         elif isinstance(item, int):
             flatten_items.append(str(item).encode())
+        elif isinstance(item, str):
+            flatten_items.append(item.encode())
         elif isinstance(item, list):
             flatten_items.append(_render_raw_list(item))
     return b"\n".join(flatten_items)

--- a/tests/cli_tests/test_shell_pipeline.py
+++ b/tests/cli_tests/test_shell_pipeline.py
@@ -9,3 +9,13 @@ def test_running_disable_shell_pipeline():
     cli.sendline("get foo | grep w")
     cli.expect(r"hello")
     cli.close()
+
+
+def test_running_disable_shell_pipeline_with_decode_option():
+    cli = pexpect.spawn("iredis -n 15 --decode=utf-8", timeout=2)
+    cli.expect("127.0.0.1")
+    cli.sendline("set foo hello")
+    cli.expect("OK")
+    cli.sendline("get foo | cat")
+    cli.expect(r"hello")
+    cli.close()


### PR DESCRIPTION
…nd shell pipeline.

Closes #383; Due to the `decode` option will decode the bytes to str,
call `subprocess.run` will a type error. This PR fixes the argument
type. And this PR also fix the nested list response via calling
`redner_raw` method.