### PR TITLE
build: use lighter `poetry-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,5 +52,5 @@ pexpect = "^4.7"
 iredis = 'iredis.entry:main'
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
👋 Thanks for `iredis`, very happy user here!

Just noticed the project is still using the full `poetry` package as its build backend. There's now a preferred, lightweight `poetry-core` package. What's the benefit? To quote the [project's readme](https://github.com/python-poetry/poetry-core#why-is-this-required):

> Prior to the release of version 1.1.0, Poetry was a build as a project management tool that included a PEP 517 build backend. This was inefficient and time consuming in majority cases a PEP 517 build was required... This makes PEP 517 builds extremely fast for Poetry managed packages.
