### PR TITLE
feat: add support for configuring TLS verification policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Feature: IRedis now accept `username` for auth, redis server version under 6
   will ignore `username`.
 - Feature: IRedis support prompt now, you can customize prompt string. (thanks to [aymericbeaumet])
+- Feature: IRedis now honors the `ssl_cert_reqs` strategy, either specifying it via
+  command line (`--verify-ssl=<none|optional|required>`) or as an url parameter (`ssl_cert_reqs`)
+  when the connection is secured via tls (`rediss://`). (authored by [torrefatto])
 
 ## 1.12
 
@@ -297,3 +300,4 @@
 [sid-maddy]: https://github.com/sid-maddy
 [tssujt]: https://github.com/tssujt
 [aymericbeaumet]: https://github.com/aymericbeaumet
+[torrefatto]: https://github.com/torrefatto

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ supports similar options like redis-cli, like `-h` for redis-server's host and
 ```
 $ iredis --help
 
-Usage:  [OPTIONS] [CMD]...
+Usage: iredis [OPTIONS] [CMD]...
 
   IRedis: Interactive Redis
 
@@ -143,39 +143,60 @@ Usage:  [OPTIONS] [CMD]...
   settings.
 
 Options:
-  -h TEXT                   Server hostname (default: 127.0.0.1).
-  -p TEXT                   Server port (default: 6379).
-  -s, --socket TEXT         Server socket (overrides hostname and port).
-  -n TEXT                   Database number.(overwrites dsn/url's db number)
-  -a, --password TEXT       Password to use when connecting to the server.
-  --url TEXT                Use Redis URL to indicate connection(Can set with
-                            env `IREDIS_URL`), Example:
-                            redis://[[username]:[password]]@localhost:6379/0
-                            rediss://[[username]:[password]]@localhost:6379/0
-                            unix://[[username]:[password]]@/path/to/socket.soc
-                            k?db=0
+  -h TEXT                         Server hostname (default: 127.0.0.1).
+  -p TEXT                         Server port (default: 6379).
+  -s, --socket TEXT               Server socket (overrides hostname and port).
+  -n INTEGER                      Database number.(overwrites dsn/url's db
+                                  number)
 
-  -d, --dsn TEXT            Use DSN configured into the [alias_dsn] section of
-                            iredisrc file. (Can set with env `IREDIS_DSN`)
+  -u, --username TEXT             User name used to auth, will be ignore for
+                                  redis version < 6.
 
-  --newbie / --no-newbie    Show command hints and useful helps.
-  --iredisrc TEXT           Config file for iredis, default is ~/.iredisrc.
-  --decode TEXT             decode response, default is No decode, which will
-                            output all bytes literals.
+  -a, --password TEXT             Password to use when connecting to the
+                                  server.
 
-  --client_name TEXT        Assign a name to the current connection.
-  --raw / --no-raw          Use raw formatting for replies (default when
-                            STDOUT is not a tty). However, you can use --no-
-                            raw to force formatted output even when STDOUT is
-                            not a tty.
+  --url TEXT                      Use Redis URL to indicate connection(Can set
+                                  with env `IREDIS_URL`), Example:     redis:/
+                                  /[[username]:[password]]@localhost:6379/0
+                                  rediss://[[username]:[password]]@localhost:6
+                                  379/0     unix://[[username]:[password]]@/pa
+                                  th/to/socket.sock?db=0
 
-  --rainbow / --no-rainbow  Display colorful prompt.
-  --shell / --no-shell      Allow to run shell commands, default to True.
-  --pager / --no-pager      Using pager when output is too tall for your
-                            window, default to True.
+  -d, --dsn TEXT                  Use DSN configured into the [alias_dsn]
+                                  section of iredisrc file. (Can set with env
+                                  `IREDIS_DSN`)
 
-  --version                 Show the version and exit.
-  --help                    Show this message and exit.
+  --newbie / --no-newbie          Show command hints and useful helps.
+  --iredisrc TEXT                 Config file for iredis, default is
+                                  ~/.iredisrc.
+
+  --decode TEXT                   decode response, default is No decode, which
+                                  will output all bytes literals.
+
+  --client_name TEXT              Assign a name to the current connection.
+  --raw / --no-raw                Use raw formatting for replies (default when
+                                  STDOUT is not a tty). However, you can use
+                                  --no-raw to force formatted output even when
+                                  STDOUT is not a tty.
+
+  --rainbow / --no-rainbow        Display colorful prompt.
+  --shell / --no-shell            Allow to run shell commands, default to
+                                  True.
+
+  --pager / --no-pager            Using pager when output is too tall for your
+                                  window, default to True.
+
+  --verify-ssl [none|optional|required]
+                                  Set the TLS certificate verification
+                                  strategy
+
+  --prompt TEXT                   Prompt format (supported interpolations:
+                                  {client_name}, {db}, {host}, {path}, {port},
+                                  {username}, {client_addr}, {client_id}).
+
+  --version                       Show the version and exit.
+  --help                          Show this message and exit.
+
 ```
 
 ### Using DSN

--- a/iredis/client.py
+++ b/iredis/client.py
@@ -81,9 +81,7 @@ class Client:
         if prompt:
             self.prompt = prompt
 
-        self.verify_ssl = None
-        if self.scheme == "rediss":
-            self.verify_ssl = verify_ssl if verify_ssl is not None else "required"
+        self.verify_ssl = verify_ssl or "required"
 
         self.client_id = None
         self.client_addr = None

--- a/iredis/client.py
+++ b/iredis/client.py
@@ -20,7 +20,6 @@ from redis.exceptions import (
     ResponseError,
 )
 
-
 from . import markdown, renders
 from .data import commands as commands_data
 from .commands import (
@@ -64,6 +63,7 @@ class Client:
         username=None,
         client_name=None,
         prompt=None,
+        verify_ssl=None,
     ):
         self.host = host
         self.port = port
@@ -80,6 +80,10 @@ class Client:
             self.prompt = config.prompt
         if prompt:
             self.prompt = prompt
+
+        self.verify_ssl = None
+        if self.scheme == "rediss":
+            self.verify_ssl = verify_ssl if verify_ssl is not None else "required"
 
         self.client_id = None
         self.client_addr = None
@@ -125,6 +129,7 @@ class Client:
             self.path,
             self.scheme,
             self.username,
+            self.verify_ssl,
             client_name=self.client_name,
         )
 
@@ -137,6 +142,7 @@ class Client:
         path=None,
         scheme="redis",
         username=None,
+        verify_ssl=None,
         client_name=None,
     ):
         if scheme in ("redis", "rediss"):
@@ -154,6 +160,7 @@ class Client:
                 connection_kwargs["username"] = username
 
             if scheme == "rediss":
+                connection_kwargs["ssl_cert_reqs"] = verify_ssl
                 connection_class = SSLConnection
             else:
                 connection_class = Connection

--- a/iredis/config.py
+++ b/iredis/config.py
@@ -8,7 +8,6 @@ from . import data as project_data
 # TODO verbose logger to print to stdout
 logger = logging.getLogger(__name__)
 
-
 system_config_file = "/etc/iredisrc"
 pwd_config_file = os.path.join(os.getcwd(), ".iredisrc")
 
@@ -40,6 +39,7 @@ class Config:
         self.shell = None
         self.enable_pager = None
         self.pager = None
+        self.verify_ssl = None
 
         self.warning = True
 

--- a/iredis/entry.py
+++ b/iredis/entry.py
@@ -237,6 +237,7 @@ Use Redis URL to indicate connection(Can set with env `IREDIS_URL`), Example:
 """
 SHELL = """Allow to run shell commands, default to True."""
 PAGER_HELP = """Using pager when output is too tall for your window, default to True."""
+VERIFY_SSL_HELP = """Set the TLS certificate verification strategy"""
 
 
 # command line entry here...
@@ -274,6 +275,12 @@ PAGER_HELP = """Using pager when output is too tall for your window, default to 
 @click.option("--shell/--no-shell", default=None, is_flag=True, help=SHELL)
 @click.option("--pager/--no-pager", default=None, is_flag=True, help=PAGER_HELP)
 @click.option(
+    "--verify-ssl",
+    default=None,
+    type=click.Choice(["none", "optional", "required"]),
+    help=VERIFY_SSL_HELP,
+)
+@click.option(
     "--prompt",
     default=None,
     help=(
@@ -302,6 +309,7 @@ def gather_args(
     socket,
     shell,
     pager,
+    verify_ssl,
     prompt,
 ):
     """
@@ -344,6 +352,8 @@ def gather_args(
         config.shell = shell
     if pager is not None:
         config.enable_pager = pager
+    if verify_ssl is not None:
+        config.verify_ssl = verify_ssl
 
     return ctx
 
@@ -384,6 +394,7 @@ def create_client(params):
     password = params["password"]
     client_name = params["client_name"]
     prompt = params["prompt"]
+    verify_ssl = params["verify_ssl"]
 
     dsn_from_url = None
     dsn = params["dsn"]
@@ -395,6 +406,7 @@ def create_client(params):
     if dsn_from_url:
         # db from command lint options should be high priority
         db = db if db else dsn_from_url.db
+        verify_ssl = verify_ssl if verify_ssl else dsn_from_url.verify_ssl
         return Client(
             host=dsn_from_url.host,
             port=dsn_from_url.port,
@@ -405,6 +417,7 @@ def create_client(params):
             username=dsn_from_url.username,
             client_name=client_name,
             prompt=prompt,
+            verify_ssl=verify_ssl,
         )
     if params["socket"]:
         return Client(
@@ -424,6 +437,7 @@ def create_client(params):
         password=password,
         client_name=client_name,
         prompt=prompt,
+        verify_ssl=verify_ssl,
     )
 
 

--- a/iredis/entry.py
+++ b/iredis/entry.py
@@ -406,7 +406,7 @@ def create_client(params):
     if dsn_from_url:
         # db from command lint options should be high priority
         db = db if db else dsn_from_url.db
-        verify_ssl = verify_ssl if verify_ssl else dsn_from_url.verify_ssl
+        verify_ssl = verify_ssl or dsn_from_url.verify_ssl
         return Client(
             host=dsn_from_url.host,
             port=dsn_from_url.port,

--- a/tests/unittests/test_entry.py
+++ b/tests/unittests/test_entry.py
@@ -107,6 +107,7 @@ def test_command_shell_options_higher_priority():
                 db=3,
                 username=None,
                 password=None,
+                verify_ssl=None,
             ),
         ),
         (
@@ -119,6 +120,7 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username=None,
                 password=None,
+                verify_ssl=None,
             ),
         ),
         (
@@ -131,6 +133,20 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username=None,
                 password=None,
+                verify_ssl=None,
+            ),
+        ),
+        (
+            "rediss://localhost:6379/1?ssl_cert_reqs=optional",
+            DSN(
+                scheme="rediss",
+                host="localhost",
+                port=6379,
+                path=None,
+                db=1,
+                username=None,
+                password=None,
+                verify_ssl="optional",
             ),
         ),
         (
@@ -143,6 +159,7 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username="username",
                 password="password",
+                verify_ssl=None,
             ),
         ),
         (
@@ -155,6 +172,7 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username=None,
                 password="password",
+                verify_ssl=None,
             ),
         ),
         (
@@ -167,6 +185,7 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username="username",
                 password=None,
+                verify_ssl=None,
             ),
         ),
         (
@@ -180,6 +199,7 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username="username",
                 password=None,
+                verify_ssl=None,
             ),
         ),
         (
@@ -192,6 +212,7 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username="username",
                 password="password2",
+                verify_ssl=None,
             ),
         ),
         (
@@ -204,6 +225,7 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username=None,
                 password="password3",
+                verify_ssl=None,
             ),
         ),
         (
@@ -216,6 +238,7 @@ def test_command_shell_options_higher_priority():
                 db=0,
                 username=None,
                 password=None,
+                verify_ssl=None,
             ),
         ),
     ],


### PR DESCRIPTION
Hi! Thanks for this very nice piece of software. First of all, I would like to compliment you for the high quality python code in this repo. It is refreshing to read it.

I am opening this PR to add support for explicit configuration of the `ssl_cert_reqs` parameter, in case the connection schema is `rediss`. I took the liberty to also update the `README` with an updated `iredis --help`.

To pass values to the underlying `SSLConnection` object, the user has now two choices:
  - specify the value of `ssl_cert_reqs` as a query parameter in the url specified via `--url`
  - specify such value using the `--verify-ssl` option

Both check that the value be among `none`, `optional` or `required`, and the former takes precedence over the latter (same behavior as the `db` parameter).

This should tackle issue [403](https://github.com/laixintao/iredis/issues/403).