### PR TITLE
deprecate importlib_resources. use buildin now.

### DIFF
--- a/iredis/client.py
+++ b/iredis/client.py
@@ -7,7 +7,7 @@ import sys
 import codecs
 import logging
 from subprocess import run
-from importlib_resources import read_text
+from importlib.resources import read_text
 from packaging.version import parse as version_parse
 
 import redis

--- a/iredis/commands.py
+++ b/iredis/commands.py
@@ -3,7 +3,7 @@ import csv
 import json
 import logging
 import functools
-from importlib_resources import read_text, open_text
+from importlib.resources import read_text, open_text
 
 from .utils import timer, strip_quote_args
 from .exceptions import InvalidArguments, AmbiguousCommand

--- a/iredis/config.py
+++ b/iredis/config.py
@@ -1,4 +1,4 @@
-from importlib_resources import path
+from importlib.resources import path
 import os
 import logging
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -85,24 +85,6 @@ perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
-name = "importlib-resources"
-version = "5.12.0"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "importlib_resources-5.12.0-py3-none-any.whl", hash = "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"},
-    {file = "importlib_resources-5.12.0.tar.gz", hash = "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -387,4 +369,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "312b85309163abbb107a13dd4609c0a6dc97d8fa6634793e77578b73381909bf"
+content-hash = "da6f577db0d01af5d506d39dfb7877b12af13ad62e25146a3442363be26cdc8d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ mistune = "^2.0"
 configobj = "^5.0"
 click = "^7.0"
 pendulum = "^2.0"
-importlib-resources = "^5.1.0"
 # wcwidth 0.2.x uses pkg_resources which is not supported by PyOxidizer
 wcwidth = "0.1.9"
 packaging = "^21.3"

--- a/tests/unittests/test_markdown_doc_render.py
+++ b/tests/unittests/test_markdown_doc_render.py
@@ -6,7 +6,7 @@ https://github.com/antirez/redis-doc/commit/02b3d1a345093c1794fd86273e9d516fffd3
 """
 
 import pytest
-from importlib_resources import read_text
+from importlib.resources import read_text
 
 from iredis.commands import commands_summary
 from iredis.data import commands as commands_data


### PR DESCRIPTION
close #466 