### PR TITLE
drop python 3.7 support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
           architecture: 'x64'
       - name: Cache venv
         uses: actions/cache@v1
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
           architecture: 'x64'
       - name: Cache venv
         uses: actions/cache@v1

--- a/.github/workflows/test-binary-build.yaml
+++ b/.github/workflows/test-binary-build.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
           architecture: 'x64'
       - name: Cache venv
         uses: actions/cache@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11.1"]
+        python: ["3.8", "3.9", "3.10", "3.11.1"]
         redis: [5, 6, 7, 7.2]
     runs-on: ${{ matrix.os }}
 
@@ -65,7 +65,7 @@ jobs:
           skip: ./docs/assets/demo.svg,./iredis/data/commands.json,./iredis/data/commands/*,./tests/unittests/*
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
           architecture: "x64"
       - name: Cache venv
         uses: actions/cache@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
 <a href="https://github.com/laixintao/iredis/actions"><img src="https://github.com/laixintao/iredis/workflows/Test/badge.svg" alt="Github Action"></a>
 <a href="https://badge.fury.io/py/iredis"><img src="https://badge.fury.io/py/iredis.svg" alt="PyPI version"></a>
-<img src="https://badgen.net/badge/python/3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11" alt="Python version">
+<img src="https://badgen.net/badge/python/3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11" alt="Python version">
 <a href="https://pepy.tech/project/iredis"><img src="https://pepy.tech/badge/iredis" alt="Download stats"></a>
 </p>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ classifiers = [
     "Environment :: Console :: Curses",
     "Environment :: MacOS X",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -31,7 +30,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 prompt_toolkit = "^3"
 Pygments = "^2"
 mistune = "^3.0"


### PR DESCRIPTION
necessary to update to [pendulum 3.0.0](https://github.com/sdispater/pendulum/releases/tag/3.0.0), which doesn't support python 3.7 anymore.
Btw, [python 3.7 is unsupported by python since June of this year](https://devguide.python.org/versions/).