### PR TITLE
upgrade python syntax to python 3.8+

### DIFF
--- a/iredis/completers.py
+++ b/iredis/completers.py
@@ -139,8 +139,7 @@ class TimestampCompleter(Completer):
         )
 
         # here we yield bigger timestamp first.
-        for completion in sorted(completions, key=lambda a: a.text):
-            yield completion
+        yield from sorted(completions, key=lambda a: a.text)
 
 
 class IRedisCompleter(Completer):
@@ -290,7 +289,7 @@ class IRedisCompleter(Completer):
         self.key_completer.touch_words(ensure_str(items))
 
     def __repr__(self) -> str:
-        return "DynamicCompleter(%r -> %r)" % (
+        return "DynamicCompleter({!r} -> {!r})".format(
             self.get_completer,
             self.current_completer,
         )

--- a/iredis/config.py
+++ b/iredis/config.py
@@ -88,13 +88,13 @@ def read_config_file(f):
         config = ConfigObj(f, interpolation=False, encoding="utf8")
     except ConfigObjError as e:
         logger.error(
-            "Unable to parse line {0} of config file " "'{1}'.".format(e.line_number, f)
+            "Unable to parse line {} of config file " "'{}'.".format(e.line_number, f)
         )
         logger.error("Using successfully parsed config values.")
         return e.config
-    except (IOError, OSError) as e:
+    except OSError as e:
         logger.error(
-            "You don't have permission to read " "config file '{0}'.".format(e.filename)
+            "You don't have permission to read " "config file '{}'.".format(e.filename)
         )
         return None
 

--- a/iredis/entry.py
+++ b/iredis/entry.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import logging
 import sys

--- a/iredis/markdown.py
+++ b/iredis/markdown.py
@@ -39,7 +39,7 @@ class TerminalRender(mistune.HTMLRenderer):
         tag = "ul"
         if ordered:
             tag = "ol"
-        return "<%s>%s</%s>\n" % (tag, body, tag)
+        return "<{}>{}</{}>\n".format(tag, body, tag)
 
     def list_item(self, text, *args):
         """Rendering list item snippet. Like ``<li>``."""
@@ -62,5 +62,5 @@ def replace_to_markdown_title(original):
 def render(text):
     replaced = replace_to_markdown_title(text)
     html_text = markdown_render(replaced)
-    logger.debug("[Document] {} ...".format(html_text)[:20])
+    logger.debug(f"[Document] {html_text} ..."[:20])
     return to_formatted_text(HTML(html_text))

--- a/iredis/warning.py
+++ b/iredis/warning.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-
 import sys
 import click
 from .commands import dangerous_commands

--- a/tests/cli_tests/test_config.py
+++ b/tests/cli_tests/test_config.py
@@ -19,7 +19,7 @@ def test_log_location_config():
 
     log = Path("/tmp/iredis1.log")
     assert log.exists()
-    with open(log, "r") as logfile:
+    with open(log) as logfile:
         content = logfile.read()
 
     assert len(content) > 100

--- a/tests/cli_tests/test_history.py
+++ b/tests/cli_tests/test_history.py
@@ -10,7 +10,7 @@ def test_history_not_log_auth(cli):
     cli.sendline("set foo bar")
     cli.expect("OK")
 
-    with open(os.path.expanduser("~/.iredis_history"), "r") as history_file:
+    with open(os.path.expanduser("~/.iredis_history")) as history_file:
         content = history_file.read()
 
     assert "set foo bar" in content
@@ -36,7 +36,7 @@ def test_history_create_and_writing_with_config():
     log = Path("/tmp/iredis_history.txt")
     assert log.exists()
 
-    with open(log, "r") as logfile:
+    with open(log) as logfile:
         content = logfile.read()
 
     assert "set hello world" in content

--- a/tests/cli_tests/test_pager.py
+++ b/tests/cli_tests/test_pager.py
@@ -13,12 +13,12 @@ TEST_IREDISRC = "/tmp/.iredisrc.test"
 TEST_PAGER_BOUNDARY = "---boundary---"
 TEST_PAGER_BOUNDARY_NUMBER = "---88938347271---"
 
-env_pager = "{0} {1} {2}".format(
+env_pager = "{} {} {}".format(
     sys.executable,
     os.path.join(pathlib.Path(__file__).parent, "wrappager.py"),
     TEST_PAGER_BOUNDARY,
 )
-env_pager_numbers = "{0} {1} {2}".format(
+env_pager_numbers = "{} {} {}".format(
     sys.executable,
     os.path.join(pathlib.Path(__file__).parent, "wrappager.py"),
     TEST_PAGER_BOUNDARY_NUMBER,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ def judge_command():
             return
 
         variables = m.variables()
-        print("Found variables: {}".format(variables))
+        print(f"Found variables: {variables}")
         for expect_token, expect_value in expect.items():
             all_variables = variables.getall(expect_token)
             if len(all_variables) > 1:


### PR DESCRIPTION
just running `pyupgrade  --py38-plus {iredis,tests}/**/*.py`.