### PR TITLE
bugfix: split_command_args trate the \n to 2 chars in quotes.

### DIFF
--- a/iredis/commands.py
+++ b/iredis/commands.py
@@ -120,7 +120,7 @@ def split_command_args(command):
         # `command` with `args` is ('in') which is an invalid case.
         normalized_input_command = " ".join(command.split()).upper()
         if (
-            re.search("\s", command)
+            re.search(r"\s", command)
             and command_name.startswith(normalized_input_command)
             and command_name != normalized_input_command
         ):

--- a/iredis/utils.py
+++ b/iredis/utils.py
@@ -39,10 +39,11 @@ def literal_bytes(b):
     return b
 
 
-def _valid_token(words):
-    token = "".join(words).strip()
-    if token:
-        yield token
+def nappend(word, c, pre_back_slash):
+    if pre_back_slash and c == "n":  # \n
+        word[-1] = "\n"
+    else:
+        word.append(c)
 
 
 def strip_quote_args(s):
@@ -69,7 +70,7 @@ def strip_quote_args(s):
                     # previous char is \ , merge with current "
                     word[-1] = char
             else:
-                word.append(char)
+                nappend(word, char, pre_back_slash)
         # not in quote
         else:
             # separator
@@ -81,7 +82,7 @@ def strip_quote_args(s):
             elif char in ["'", '"']:
                 in_quote = char
             else:
-                word.append(char)
+                nappend(word, char, pre_back_slash)
         if char == "\\" and not pre_back_slash:
             pre_back_slash = True
         else:

--- a/tests/unittests/test_entry.py
+++ b/tests/unittests/test_entry.py
@@ -75,12 +75,10 @@ def test_command_shell_options_higher_priority():
     from iredis.config import config
     from textwrap import dedent
 
-    config_content = dedent(
-        """
+    config_content = dedent("""
         [main]
         shell = False
-        """
-    )
+        """)
     with open("/tmp/iredisrc", "w+") as etc_config:
         etc_config.write(config_content)
 

--- a/tests/unittests/test_entry.py
+++ b/tests/unittests/test_entry.py
@@ -75,10 +75,12 @@ def test_command_shell_options_higher_priority():
     from iredis.config import config
     from textwrap import dedent
 
-    config_content = dedent("""
+    config_content = dedent(
+        """
         [main]
         shell = False
-        """)
+        """
+    )
     with open("/tmp/iredisrc", "w+") as etc_config:
         etc_config.write(config_content)
 

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -55,6 +55,7 @@ def test_timer():
         (r'""', [""]),  # set foo "" is a legal command
         (r"\\", ["\\\\"]),  # backslash are legal
         ("\\hello\\", ["\\hello\\"]),  # backslash are legal
+        ('foo "bar\\n1"', ["foo", "bar\n1"]),
     ],
 )
 def test_stripe_quote_escape_in_quote(test_input, expected):


### PR DESCRIPTION
close #489 