### PR TITLE
fix: MOVED was not being redirected

### DIFF
--- a/iredis/client.py
+++ b/iredis/client.py
@@ -18,6 +18,7 @@ from redis.connection import Connection, SSLConnection, UnixDomainSocketConnecti
 from redis.exceptions import (
     AuthenticationError,
     ConnectionError,
+    MovedError,
     TimeoutError,
     ResponseError,
 )
@@ -298,6 +299,10 @@ class Client:
             except redis.exceptions.ExecAbortError:
                 config.transaction = False
                 raise
+            except MovedError as e:
+                return self.reissue_with_redirect(
+                    f"MOVED {str(e)}", command_name, *args, **options
+                )
             except ResponseError as e:
                 response_message = str(e)
                 if response_message.startswith("MOVED"):

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -495,10 +495,28 @@ def test_mem_not_called_when_cant_get_server_version(
     assert result[0][1] == ("", "string (embstr), ttl: -1")
 
 
-def test_reissue_command_on_redis_cluster(iredis_client, clean_redis):
+def test_reissue_command_on_redis_cluster_on_old_redispy(iredis_client, clean_redis):
+    # In redis<6, MOVED errors caused ResponseError instead of MovedError to be raised
     mock_response = iredis_client.connection = MagicMock()
     mock_response.read_response.side_effect = redis.exceptions.ResponseError(
         "MOVED 12182 127.0.0.1:7002"
+    )
+    iredis_client.reissue_with_redirect = MagicMock()
+    iredis_client.execute("set", "foo", "bar")
+    assert iredis_client.reissue_with_redirect.call_args == (
+        (
+            "MOVED 12182 127.0.0.1:7002",
+            "set",
+            "foo",
+            "bar",
+        ),
+    )
+
+
+def test_reissue_command_on_redis_cluster(iredis_client, clean_redis):
+    mock_response = iredis_client.connection = MagicMock()
+    mock_response.read_response.side_effect = redis.exceptions.MovedError(
+        "12182 127.0.0.1:7002"
     )
     iredis_client.reissue_with_redirect = MagicMock()
     iredis_client.execute("set", "foo", "bar")


### PR DESCRIPTION
## Issue

When using `iredis` on a redis cluster, `MOVED` responses are not redirected.

After some debugging, I noticed `iredis` works when paired with `redis==5`, but not with `redis==7.2`:

<img width="1131" height="211" alt="image" src="https://github.com/user-attachments/assets/afd44817-c552-46cc-b058-33a73c53bf80" />

## Reason

Prior to redis-py 6, `MOVED` responses raised a `ResponseError("MOVED <SLOT> <ADDR>")`. When using `redis.ClusterRedis`, they raised `MovedError("<SLOT> <ADDR>")` instead.

`MovedError` is a subclass of `ResponseError`. The important part here is the error message. When raising `MovedError`, redis-py removes the `MOVED` string.

Starting from redis-py 6, the cluster parser exceptions were moved into the base parser, and so it started raising `MovedError`, without the `MOVED` string. This was changed in https://github.com/redis/redis-py/pull/3475. You can also see the [changelog for 6.0.0b1](https://github.com/redis/redis-py/releases/tag/v6.0.0b1), which explicitely lists this as a breaking change:
> Moved ClusterParser exceptions to BaseParser class (https://github.com/redis/redis-py/pull/3475) 

## Fix

We keep supporting redis-py <6, but we handle `MovedError` separately from `ResponseError`.