### PR TITLE
docs: README advertises a non-existent `--encode` option; the flag is `--decode`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ like `KEYS *` (see
 - <kbd>Ctrl</kbd> + <kbd>R</kbd> to open **reverse-i-search** to search through
   your command history.
 - Auto suggestions. (Like [fish shell](http://fishshell.com/).)
-- Support `--encode=utf-8`, to decode Redis' bytes responses.
+- Support `--decode=utf-8`, to decode Redis' bytes responses.
 - Command hint on bottom, include command syntax, supported redis version, and
   time complexity.
 - Official docs with built-in `HELP` command, try `HELP SET`!


### PR DESCRIPTION
## Problem

The feature list in `README.md` tells users to pass `--encode=utf-8`, but **no such option exists**. The flag is `--decode`.

**Doc side** — `README.md:59`:

```
- Support `--encode=utf-8`, to decode Redis' bytes responses.
```

**Code side** — `iredis/entry.py:274`:

```python
@click.option("--decode", default=None, help=DECODE_HELP)
```

This is not a cosmetic typo: `entry.py` sets no `context_settings` / `ignore_unknown_options`, so click hard-fails on the unknown flag. A user copying the README gets an immediate error instead of a running shell.

The README already contradicts itself — the `iredis --help` output pasted 120 lines further down, at `README.md:182`, lists the real flag:

```
  --decode TEXT                   decode response, default is No decode, which
```

Two more places in the repo already use the correct spelling:

- `CHANGELOG.md:173` — ``Bugfix: When IRedis start with `--decode=utf-8`, command with shell pipe will``
- `iredis/data/iredisrc:32-33` — `# decode redis response, default None` / `decode =`

A repo-wide `git grep -- '--encode'` returns **exactly one hit in the entire repository** — the README line this PR fixes.

## The change

One token on one line:

```diff
-- Support `--encode=utf-8`, to decode Redis' bytes responses.
+- Support `--decode=utf-8`, to decode Redis' bytes responses.
```

`README.md:182` (the embedded `--help` dump) is deliberately left untouched — it is already correct. No other file, no reflowing, no rewording.

## Verification

Repo-wide grep on a clean clone of `master`:

```console
$ git grep -n -- '--encode'
README.md:59:- Support `--encode=utf-8`, to decode Redis' bytes responses.

$ grep -n 'click.option("--decode"' iredis/entry.py
274:@click.option("--decode", default=None, help=DECODE_HELP)

$ grep -n 'context_settings\|ignore_unknown_options\|allow_extra_args' iredis/entry.py
(no output — unknown options are a hard failure)
```

Runtime, in a venv with `pip install -e .` (no Redis server needed; click rejects the option during argument parsing, before connecting):

```console
$ iredis --help | grep -E -- '--decode|--encode'
  --decode TEXT                   decode response, default is No decode, which

$ iredis --encode=utf-8 --help
Usage: iredis [OPTIONS] [CMD]...
Try 'iredis --help' for help.

Error: No such option '--encode'. Did you mean '--decode'?
```

Parsing the two forms directly through the click command, to capture the real exit codes:

```console
$ python run.py --encode=utf-8 --help
NoSuchOption : No such option '--encode'.
REAL exit=2

$ python run.py --decode=utf-8
PARSED-OK
SystemExit code= 0
REAL exit=0
```

`git diff --check` is clean and the diff is 1 insertion / 1 deletion in one file.

## Limitations

Documentation only — no behaviour change. `.pre-commit-config.yaml` runs black and flake8, neither of which touches Markdown, so no formatting step applies to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
